### PR TITLE
Added in postinstall & postdeploy for node pinning

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "compile": "gulp compile",
     "predeploy": "npm prune && npm install --no-optional",
     "deploy": "gulp compile --release",
-    "postdeploy": "nvm install latest && nvm use latest || echo nvm not found: ignoring",
     "test": "npm run lint:js && npm run lint:css",
     "lint:js": "xo",
     "lint:css": "gulp test:css",

--- a/package.json
+++ b/package.json
@@ -20,11 +20,13 @@
     }
   ],
   "scripts": {
+    "preinstall": "nvm install 6.9.2 && nvm use 6.9.2 || echo nvm not found: ignoring",
     "prestart": "npm prune && npm install",
     "start": "gulp serve",
     "compile": "gulp compile",
     "predeploy": "npm prune && npm install --no-optional",
     "deploy": "gulp compile --release",
+    "postdeploy": "nvm install latest && nvm use latest || echo nvm not found: ignoring",
     "test": "npm run lint:js && npm run lint:css",
     "lint:js": "xo",
     "lint:css": "gulp test:css",


### PR DESCRIPTION
Added in "postinstall" & "postdeploy" scripts to allow node version pinning via nvm, this will silently fail if nvm isn't found. Projects will use the latest/stable build by default on CI environments.